### PR TITLE
Fixed missing "unity" declaration for latest VCC Versions. Future-proofing measures added.

### DIFF
--- a/Packages/com.mmmaellon.smartobjectsync/package.json
+++ b/Packages/com.mmmaellon.smartobjectsync/package.json
@@ -3,6 +3,7 @@
     "displayName": "SmartObjectSync",
     "version": "3.10.6",
     "description": "A drop-in replacement for VRC_ObjectSync that allows for better syncing of objects in VRChat",
+    "unity": "2019.4",
     "url": "https://github.com/MMMaellon/SmartObjectSync.git",
     "dependencies": {},
     "gitDependencies": {},
@@ -19,7 +20,6 @@
     },
     "legacyFiles": {},
     "legacyPackages": [],
-    "unity": "2019.4",
     "samples": [
         {
             "displayName": "SmartObjectSync Example Scene",

--- a/Packages/com.mmmaellon.smartobjectsync/package.json
+++ b/Packages/com.mmmaellon.smartobjectsync/package.json
@@ -12,11 +12,14 @@
         "url": "https://twitter.com/MMMaellon"
     },
     "vpmDependencies": {
-        "com.vrchat.worlds": "^3.2.1"
+        "com.vrchat.worlds": "^3.4.0"
     },
     "legacyFolders": {
         "Assets\\MMMaellon\\SmartObjectSync": ""
     },
+    "legacyFiles": {},
+    "legacyPackages": [],
+    "unity": "2019.4",
     "samples": [
         {
             "displayName": "SmartObjectSync Example Scene",


### PR DESCRIPTION
Please see my commit for more detailed info. To start off, I re-added the `"unity"` declaration because Creator Companion v2.2.x and newer requires it in order to read supported Unity versions (since we are now using 2022). This fixes an issue where the VCC would give the user a pop-up message upon adding to the project, reading _"This package does not specify a minimum Unity version. It may not work correctly."_

I set the declaration to `"unity": "2019.4"` to ensure SmartObjectSync tells the VCC that it supports the minimum requirement of Unity 2019. Since it's a minimum declaration, the VCC will also assume that any Unity version that is newer than what is declared is also supported automatically. This tells the VCC that this package supports both Unity 2019 and Unity 2022.

In addition, I bumped the `"vpmDependencies"` line to `"com.vrchat.worlds": "^3.4.0"` to fully ensure it requires a minimum SDK version that has UdonSharp integrated. This is a future-proofing measure since SmartObjectSync requires UdonSharp. I chose this because v3.4.x versions are both the first ones to integrate UdonSharp, and are the last remaining SDKs to support Unity 2019. So those who are still sticking with Unity 2019 can continue to use SmartObjectSync with SDK v3.4.0 to v3.4.2 until they feel ready to upgrade to Unity 2022 and SDK v3.5+.

_Of course, if for any reason you add features to SmartObjectSync or any of your Packages that requires newer SDK functionality (like Udon 2, if that ever happens), you will want to bump up both `"unity"` and `"vpmDependencies"` declarations respectively. How the `"unity"` declaration works is, for example, if you attempt to add a Package to a 2019 Project that requires 2022, the VCC will stop the user from doing so until they migrate their project._

Finally, I also went ahead and added all unused VPM specific declarations for you as well. Their fields are left empty on purpose. This is for you to use them in the future, if necessary.

**NOTE TO MMMaellon:** I did not bump the `"version"` number of SmartObjectSync. That was on purpose. I prefer you handle that part yourself.

Thanks!